### PR TITLE
Nicer match audits

### DIFF
--- a/LBHVerificationHubAPI/Connected Services/ClearCoreService/Reference.cs
+++ b/LBHVerificationHubAPI/Connected Services/ClearCoreService/Reference.cs
@@ -7,6 +7,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace ClearCoreService
 {
     using System.Runtime.Serialization;

--- a/LBHVerificationHubAPI/Controllers/V1/PPVerifyController.cs
+++ b/LBHVerificationHubAPI/Controllers/V1/PPVerifyController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using LBHVerificationHubAPI.UseCases.V1.Objects;
@@ -6,6 +7,8 @@ using LBHVerificationHubAPI.Infrastructure.V1.API;
 using LBHVerificationHubAPI.Extensions.Controller;
 using LBHVerificationHubAPI.UseCases.V1.Search.Models;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace LBHVerificationHubAPI.Controllers.V1
 {
@@ -17,10 +20,12 @@ namespace LBHVerificationHubAPI.Controllers.V1
     public class PPVerifyController : BaseController
     {
         private readonly IVerifyUseCase _verifyUseCase;
+        private readonly ILogger<PPVerifyController> _logger;
 
-        public PPVerifyController(IVerifyUseCase VerifyUseCase)
+        public PPVerifyController(IVerifyUseCase VerifyUseCase, ILogger<PPVerifyController> logger)
         {
             _verifyUseCase = VerifyUseCase;
+            _logger = logger;
         }
 
         /// <summary>
@@ -29,12 +34,26 @@ namespace LBHVerificationHubAPI.Controllers.V1
         /// <returns></returns>
         [HttpPost]
         [ProducesResponseType(typeof(APIResponse<ParkingPermitVerificationResponse>), 200)]
-        public async Task<IActionResult> Verify([FromBody][Required]ParkingPermitVerificationRequest request)
-        {            
-            var response = await _verifyUseCase.ExecuteAsync(request, HttpContext.GetCancellationToken()).ConfigureAwait(false);
+        public async Task<IActionResult> Verify([FromBody] [Required] ParkingPermitVerificationRequest request)
+        {
+            var (response, matchDescription) = await _verifyUseCase
+                .ExecuteAsync(request, HttpContext.GetCancellationToken()).ConfigureAwait(false);
+
+            var queryDictString = string.Join("\n", request.GetQueryDict()
+                .Select(m => $"  {m.Key}: {m.Value}"));
+
+            if (response.Verified)
+            {
+                _logger.LogInformation(
+                    "\n" +
+                    $"Query at {DateTime.Now}:" + "\n" +
+                    queryDictString + "\n\n" +
+                    "Audit returned:" + "\n" +
+                    $"  {matchDescription}" + "\n\n"
+                );
+            }
 
             return HandleResponse(response);
         }
-
     }
 }

--- a/LBHVerificationHubAPI/Gateways/V1/ClearCoreGateway.cs
+++ b/LBHVerificationHubAPI/Gateways/V1/ClearCoreGateway.cs
@@ -19,7 +19,7 @@ namespace LBHVerificationHubAPI.Gateways.V1
         private readonly IClearCoreSoapChannel _clearCoreSoapChannel;
         private readonly IClearCoreSoap _clearCoreSoap;
 
-        public ClearCoreGateway(IClearCoreSoapChannel clearCoreSoapChannel , string ClearCoreURL)
+        public ClearCoreGateway(IClearCoreSoapChannel clearCoreSoapChannel, string ClearCoreURL)
         {
             _clearCoreSoapChannel = clearCoreSoapChannel;
             _clearCoreURL = ClearCoreURL;
@@ -51,6 +51,14 @@ namespace LBHVerificationHubAPI.Gateways.V1
             ClearCoreResponse response = QueryHelper.CreateResponse(results);
 
             return response;
+        }
+        
+        public async Task<List<string>> GetLateMatchAudits(string matchAudits)
+        {
+            var audits = new List<string>();
+            audits.Add(await _clearCoreSoap.SCVXlateMatchAuditAsync(Helpers.GlobalConstants.CLEARCORE_PROJECT_NAME,
+                matchAudits));
+            return audits;
         }
     }
 }

--- a/LBHVerificationHubAPI/Gateways/V1/IClearCoreGateway.cs
+++ b/LBHVerificationHubAPI/Gateways/V1/IClearCoreGateway.cs
@@ -12,5 +12,6 @@ namespace LBHVerificationHubAPI.Gateways.V1
     public interface IClearCoreGateway
     {
         Task<ClearCoreResponse> Verify(ParkingPermitVerificationRequest request, CancellationToken cancellationToken);
+        Task<List<string>> GetLateMatchAudits(string responseMatchAudit);
     }
 }

--- a/LBHVerificationHubAPI/Helpers/QueryHelper.cs
+++ b/LBHVerificationHubAPI/Helpers/QueryHelper.cs
@@ -62,6 +62,7 @@ namespace LBHVerificationHubAPI.Helpers
             {
                 verified = true;
                 response.VerificationAuditID = SaveAuditDetails(results.m_matchAudits);
+                response.matchAudits = new List<string>(results.m_matchAudits);
             }
             else
             {

--- a/LBHVerificationHubAPI/Infrastructure/V1/UseCase/IRawUseCaseAsync.cs
+++ b/LBHVerificationHubAPI/Infrastructure/V1/UseCase/IRawUseCaseAsync.cs
@@ -1,11 +1,13 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using LBHVerificationHubAPI.Infrastructure.V1.API;
+using LBHVerificationHubAPI.UseCases.V1.Search.Models;
 
 namespace LBHVerificationHubAPI.Infrastructure.V1.UseCase
 {
     public interface IRawUseCaseAsync<TRequest, TResponse> where TRequest : IRequest
     {
-        Task<TResponse> ExecuteAsync(TRequest request, CancellationToken cancellationToken);
+        Task<Tuple<ParkingPermitVerificationResponse, string>> ExecuteAsync(TRequest request, CancellationToken cancellationToken);
     }
 }

--- a/LBHVerificationHubAPI/Models/ClearCoreResponse.cs
+++ b/LBHVerificationHubAPI/Models/ClearCoreResponse.cs
@@ -11,9 +11,7 @@ namespace LBHVerificationHubAPI.Models
     public class ClearCoreResponse
     {
         public bool verified { get; set; }
-
         public string VerificationAuditID { get; set; }
-
-
+        public List<string> matchAudits;
     }
 }

--- a/LBHVerificationHubAPI/UseCases/V1/Objects/VerifyUseCase.cs
+++ b/LBHVerificationHubAPI/UseCases/V1/Objects/VerifyUseCase.cs
@@ -21,7 +21,7 @@ namespace LBHVerificationHubAPI.UseCases.V1.Objects
             _Gateway = Gateway;
         }
 
-        public async Task<ParkingPermitVerificationResponse> ExecuteAsync(ParkingPermitVerificationRequest request, CancellationToken cancellationToken)
+        public async Task<Tuple<ParkingPermitVerificationResponse,string>> ExecuteAsync(ParkingPermitVerificationRequest request, CancellationToken cancellationToken)
         {
 
             //validate
@@ -34,20 +34,23 @@ namespace LBHVerificationHubAPI.UseCases.V1.Objects
                 throw new BadRequestException(validationResponse);
 
             var response = await _Gateway.Verify(request, cancellationToken).ConfigureAwait(false);
-            var lateMatches = await _Gateway.GetLateMatchAudits(response.matchAudits[0]);
+            
+            List<string> lateMatches = new List<string>();
+            if (response.matchAudits != null)
+                lateMatches = await _Gateway.GetLateMatchAudits(response.matchAudits[0]);
+            else
+                lateMatches.Append("NONE");
 
             if (response == null)
-                return new ParkingPermitVerificationResponse();
+                return new Tuple<ParkingPermitVerificationResponse, string>(new ParkingPermitVerificationResponse(), "");
             var useCaseResponse = new ParkingPermitVerificationResponse
             {
                 Verified = response.verified,
                 VerificationAuditID = response.VerificationAuditID,
-                MatchAudits = response.matchAudits,
-                LateMatchAudits = lateMatches
             };
 
 
-            return useCaseResponse;
+            return new Tuple<ParkingPermitVerificationResponse, string>(useCaseResponse, lateMatches.FirstOrDefault());
 
 
         }

--- a/LBHVerificationHubAPI/UseCases/V1/Objects/VerifyUseCase.cs
+++ b/LBHVerificationHubAPI/UseCases/V1/Objects/VerifyUseCase.cs
@@ -35,14 +35,15 @@ namespace LBHVerificationHubAPI.UseCases.V1.Objects
 
             var response = await _Gateway.Verify(request, cancellationToken).ConfigureAwait(false);
             
+            if (response == null)
+                return new Tuple<ParkingPermitVerificationResponse, string>(new ParkingPermitVerificationResponse(), "");
+            
             List<string> lateMatches = new List<string>();
             if (response.matchAudits != null)
                 lateMatches = await _Gateway.GetLateMatchAudits(response.matchAudits[0]);
             else
                 lateMatches.Append("NONE");
 
-            if (response == null)
-                return new Tuple<ParkingPermitVerificationResponse, string>(new ParkingPermitVerificationResponse(), "");
             var useCaseResponse = new ParkingPermitVerificationResponse
             {
                 Verified = response.verified,

--- a/LBHVerificationHubAPI/UseCases/V1/Objects/VerifyUseCase.cs
+++ b/LBHVerificationHubAPI/UseCases/V1/Objects/VerifyUseCase.cs
@@ -34,13 +34,16 @@ namespace LBHVerificationHubAPI.UseCases.V1.Objects
                 throw new BadRequestException(validationResponse);
 
             var response = await _Gateway.Verify(request, cancellationToken).ConfigureAwait(false);
+            var lateMatches = await _Gateway.GetLateMatchAudits(response.matchAudits[0]);
 
             if (response == null)
                 return new ParkingPermitVerificationResponse();
             var useCaseResponse = new ParkingPermitVerificationResponse
             {
                 Verified = response.verified,
-                VerificationAuditID = response.VerificationAuditID
+                VerificationAuditID = response.VerificationAuditID,
+                MatchAudits = response.matchAudits,
+                LateMatchAudits = lateMatches
             };
 
 

--- a/LBHVerificationHubAPI/UseCases/V1/Search/Models/ParkingPermitVerificationRequest.cs
+++ b/LBHVerificationHubAPI/UseCases/V1/Search/Models/ParkingPermitVerificationRequest.cs
@@ -49,6 +49,16 @@ namespace LBHVerificationHubAPI.UseCases.V1.Search.Models
 
             return new RequestValidationResponse(validationResult);
         }
+        
+        public Dictionary<string, string> GetQueryDict()
+        {
+            var dict = new Dictionary<string, string>();
+            foreach (var prop in this.GetType().GetProperties())
+                if (prop.GetValue(this, null) != null)
+                    dict.Add(prop.Name, prop.GetValue(this, null).ToString());
+
+            return dict;
+        }
     }
 
     public class ClearCoreProperty : Attribute

--- a/LBHVerificationHubAPI/UseCases/V1/Search/Models/ParkingPermitVerificationResponse.cs
+++ b/LBHVerificationHubAPI/UseCases/V1/Search/Models/ParkingPermitVerificationResponse.cs
@@ -11,8 +11,8 @@ namespace LBHVerificationHubAPI.UseCases.V1.Search.Models
     public class ParkingPermitVerificationResponse 
     {  
         public bool Verified { get; set; }
-
         public string VerificationAuditID { get;set; }
-      
+        public List<string> MatchAudits { get; set; }
+        public List<string> LateMatchAudits { get; set; }
     }
 }

--- a/LBHVerificationHubAPI/UseCases/V1/Search/Models/ParkingPermitVerificationResponse.cs
+++ b/LBHVerificationHubAPI/UseCases/V1/Search/Models/ParkingPermitVerificationResponse.cs
@@ -12,7 +12,5 @@ namespace LBHVerificationHubAPI.UseCases.V1.Search.Models
     {  
         public bool Verified { get; set; }
         public string VerificationAuditID { get;set; }
-        public List<string> MatchAudits { get; set; }
-        public List<string> LateMatchAudits { get; set; }
     }
 }

--- a/LBHVerificationHubAPITest/Test/Controllers/V1/PPVerifyControllerTests.cs
+++ b/LBHVerificationHubAPITest/Test/Controllers/V1/PPVerifyControllerTests.cs
@@ -11,7 +11,9 @@ using Moq;
 using Xunit;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using Castle.Core.Logging;
 using LBHVerificationHubAPI.Infrastructure.V1.API;
+using Microsoft.Extensions.Logging;
 
 namespace LBHVerificationHubAPITest.Test.Controllers.V1
 {
@@ -23,19 +25,18 @@ namespace LBHVerificationHubAPITest.Test.Controllers.V1
         public PPVerifyControllerTests()
         {
             _mock = new Mock<IVerifyUseCase>();
-            _classUnderTest = new PPVerifyController(_mock.Object);
+            _classUnderTest = new PPVerifyController(_mock.Object, new Logger<PPVerifyController>(new LoggerFactory()));
         }
 
         [Fact]
         public async Task GivenValidRequest_WhenCallingVerify_ThenShouldReturn200()
         {
             _mock.Setup(s => s.ExecuteAsync(It.IsAny<ParkingPermitVerificationRequest>(), CancellationToken.None))
-                .ReturnsAsync(new ParkingPermitVerificationResponse
-                {
-                });
+                .ReturnsAsync(new Tuple<ParkingPermitVerificationResponse, string>
+                    (new ParkingPermitVerificationResponse(), "")
+                );
             var request = new ParkingPermitVerificationRequest
             {
-
             };
 
             var response = await _classUnderTest.Verify(request).ConfigureAwait(false);
@@ -44,7 +45,6 @@ namespace LBHVerificationHubAPITest.Test.Controllers.V1
             response.Should().BeOfType<ObjectResult>();
             var objectResult = response as ObjectResult;
             objectResult.StatusCode.Should().Be(200);
-
         }
 
         [Fact]
@@ -52,10 +52,9 @@ namespace LBHVerificationHubAPITest.Test.Controllers.V1
         {
             //arrange
             _mock.Setup(s => s.ExecuteAsync(It.IsAny<ParkingPermitVerificationRequest>(), CancellationToken.None))
-                .ReturnsAsync(new ParkingPermitVerificationResponse
-                {
-                    
-                });
+                .ReturnsAsync(new Tuple<ParkingPermitVerificationResponse, string>
+                    (new ParkingPermitVerificationResponse(), "")
+                );
 
             var request = new ParkingPermitVerificationRequest
             {
@@ -69,6 +68,5 @@ namespace LBHVerificationHubAPITest.Test.Controllers.V1
             var apiResponse = objectResult?.Value as APIResponse<ParkingPermitVerificationResponse>;
             apiResponse.Should().NotBeNull();
         }
-
     }
 }

--- a/LBHVerificationHubAPITest/Test/UseCases/V1/VerifyUseCaseTest.cs
+++ b/LBHVerificationHubAPITest/Test/UseCases/V1/VerifyUseCaseTest.cs
@@ -69,8 +69,8 @@ namespace LBHVerificationHubAPITest.Test.UseCases.V1
         public async Task Given_ValidRequest_ThenShouldGiveValidResponse()
         {
             //arrange
-            var request = new ParkingPermitVerificationRequest() { ForeName = "forename", Surname = "surname", UPRN = "UPRN" };
-            ParkingPermitVerificationResponse response = await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+            var request = new ParkingPermitVerificationRequest() { ForeName = "VHUB", Surname = "TEST", UPRN = "100021021404" };
+            var (response, _) = await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
 
             response.Should().NotBeNull();
             response.Should().BeOfType<ParkingPermitVerificationResponse>();


### PR DESCRIPTION
### Implement logging for verification requests returning True
- Change VerifyUseCase to return a `Tuple<...Request, string>`, where the string contains the `MatchAudit`
- Create a logger for `PPVerifyController`
- Implement a method which reflects `ParkingPermitVerificationRequest`, creating a list of provided request parameters.
- Remove match audits and their generated interpretation from the payload.
- Add logging to `PPVerifyController` on results, where `Verified == true`
- Fix some tests to support altered method signatures